### PR TITLE
Add code of conduct

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -143,7 +143,7 @@ report, we will take appropriate action.
 <!-- For information on enforcement, please view the [*Enforcement
 Manual*](enforcement). -->
 
-Original text courtesy of the [*Speak
+Original text courtesy of [Project Jupyter](https://github.com/jupyter/governance/blob/3785332602464a85b912479a607b4cd595e0f17a/conduct/code_of_conduct.md), which gives credit to the [*Speak
 Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html)
 and [*Django*](https://www.djangoproject.com/conduct) Projects,
 modified by Bqplot.  We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -129,7 +129,7 @@ If you believe someone is violating the code of conduct, please report this in
 a timely manner. Code of conduct violations reduce the value of the community
 for everyone and we take them seriously.
 
-You can file a report by emailing [EMAIL](EMAIL) or by filing out [this form](GOOGLE FORM).
+You can file a report by emailing [EMAIL](EMAIL) or by filling out [this form](GOOGLE FORM).
 For more details or information on reporting in-person at an event, please see our
 Reporting Guidelines.
 

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,152 @@
+# Bqplot Code of Conduct
+
+Bqplot is an engaged and respectful community made up of people
+from all over the world. Your involvement helps us to further our
+mission and to create an open platform that serves a broad range of
+communities, from research and education, to journalism, industry and
+beyond.
+
+Naturally, this implies diversity of ideas and perspectives on often complex
+problems. Disagreement and healthy discussion of conflicting viewpoints is
+welcome: the best solutions to hard problems rarely come from a single angle.
+But disagreement is not an excuse for aggression: humans tend to take
+disagreement personally and easily drift into behavior that ultimately degrades
+a community. This is particularly acute with online communication across
+language and cultural gaps, where many cues of human behavior are unavailable.
+We are outlining here a set of principles and processes to support a
+healthy community in the face of these challenges.
+
+Fundamentally, we are committed to fostering a productive, harassment-free
+environment for everyone. Rather than considering this code an exhaustive list
+of things that you can’t do, take it in the spirit it is intended - a guide to
+make it easier to enrich all of us and the communities in which we participate.
+
+Importantly: as a member of our community, *you are also a steward of these
+values*.  Not all problems need to be resolved via formal processes, and often
+a quick, friendly but clear word on an online forum or in person can help
+resolve a misunderstanding and de-escalate things.
+
+However, sometimes these informal processes may be inadequate: they fail to
+work, there is urgency or risk to someone, nobody is intervening publicly and
+you don't feel comfortable speaking in public, etc.  For these or other
+reasons, structured follow-up may be necessary and here we provide the means
+for that: we welcome reports by emailing
+[*EMAIL*]() or by filling out [this
+form](GOOGLE FORM).
+
+This code applies equally to founders, developers, mentors and new community
+members, in all spaces managed by Bqplot. This
+includes the mailing lists, our GitHub organizations, our chat rooms, in-person
+events, and any other forums created by the project team. In addition,
+violations of this code outside these spaces may affect a person's ability to
+participate within them.
+
+## Expected behavior
+
+By embracing the following principles, guidelines and actions to follow or
+avoid, you will help us make Bqplot a welcoming and productive community. Feel
+free to contact the Steering Committee at
+[*EMAIL*](EMAIL) with any questions.
+
+1. **Be friendly and patient**.
+
+2. **Be welcoming**. We strive to be a community that welcomes and supports
+   people of all backgrounds and identities. This includes, but is not limited
+   to, members of any race, ethnicity, culture, national origin, color,
+   immigration status, social and economic class, educational level, sex, sexual
+   orientation, gender identity and expression, age, physical appearance, family
+   status, technological or professional choices, academic
+   discipline, religion, mental ability, and physical ability.
+
+3. **Be considerate**. Your work will be used by other people, and you in turn
+   will depend on the work of others. Any decision you take will affect users
+   and colleagues, and you should take those consequences into account when
+   making decisions. Remember that we're a world-wide community. You may be
+   communicating with someone with a different primary language or cultural
+   background.
+
+4. **Be respectful**. Not all of us will agree all the time, but disagreement is
+   no excuse for poor behavior or poor manners. We might all experience some
+   frustration now and then, but we cannot allow that frustration to turn into a
+   personal attack. It’s important to remember that a community where people
+   feel uncomfortable or threatened is not a productive one.
+
+5. **Be careful in the words that you choose**. Be kind to others. Do not insult
+   or put down other community members. Harassment and other exclusionary
+   behavior are not acceptable. This includes, but is not limited to:
+   * Violent threats or violent language directed against another person
+   * Discriminatory jokes and language
+   * Posting sexually explicit or violent material
+   * Posting (or threatening to post) other people's personally identifying
+     information ("doxing")
+   * Personal insults, especially those using racist or sexist terms
+   * Unwelcome sexual attention
+   * Advocating for, or encouraging, any of the above behavior
+   * Repeated harassment of others. In general, if someone asks you to stop,
+     then stop
+
+6. **Moderate your expectations**. Please respect that community members choose
+   how they spend their time in the project. A thoughtful question about your
+   expectations is preferable to demands for another person's time.
+
+7. **When we disagree, try to understand why**. Disagreements, both social and
+   technical, happen all the time and Bqplot is no exception.  Try to
+   understand where others are coming from, as seeing a question from their
+   viewpoint may help find a new path forward.  And don’t forget that it is
+   human to err: blaming each other doesn’t get us anywhere, while we can learn
+   from mistakes to find better solutions.
+
+8. **A simple apology can go a long way**. It can often de-escalate a situation,
+   and telling someone that you are sorry is an act of empathy that doesn’t
+   automatically imply an admission of guilt.
+
+
+## Responding to inappropriate behavior
+
+In some cases, individuals may violate the CoC in online or in-person situations.
+If any community member deems the action to be harmful to the community,
+they may act immediately to defuse the situation.
+This includes actions directed at the situation, rather than at an individual, such
+as locking a thread, *temporarily* suspending a user's account in the
+community forum, calling a meeting break, or generally acting to
+de-escalate the situation. Follow-up your actions by
+[reporting the incident to the CoC committee](#Reporting).
+
+If the incident involves physical danger, or involves a threat to anyone's safety
+(such as threats of violence), any member of the community may -- and should -- act
+unilaterally to protect the safety of any community member.
+This can include contacting law enforcement, other members of the Bqplot community,
+or other local personnel that are present.
+
+In situations where an individual community member acts unilaterally,
+they must inform the Code of Conduct committee as soon as possible,
+by emailing [EMAIL](EMAIL) within 24 hours.
+
+
+## Reporting
+
+If you believe someone is violating the code of conduct, please report this in
+a timely manner. Code of conduct violations reduce the value of the community
+for everyone and we take them seriously.
+
+You can file a report by emailing [EMAIL](EMAIL) or by filing out [this form](GOOGLE FORM).
+For more details or information on reporting in-person at an event, please see our
+Reporting Guidelines.
+
+The online form gives you the option to keep your report anonymous or request
+that we follow up with you directly. While we cannot follow up on an anonymous
+report, we will take appropriate action.
+
+
+## Enforcement
+
+<!-- For information on enforcement, please view the [*Enforcement
+Manual*](enforcement). -->
+
+Original text courtesy of the [*Speak
+Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html)
+and [*Django*](https://www.djangoproject.com/conduct) Projects,
+modified by Bqplot.  We are grateful to those projects for contributing these materials under open licensing terms for us to easily reuse.
+
+All content on this page is licensed under a [*Creative Commons
+Attribution*](http://creativecommons.org/licenses/by/3.0/) license.


### PR DESCRIPTION
As discussed, this is essentially the same CoC as for Project Jupyter.

 - We are not making a distinction between the steering committee and the code of conduct.
 - I have left the link to the enforecement document out until I add the enforcement document.

We need to set up an email to the steering committee, and a reporting google form.